### PR TITLE
Upgrade to 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 ### Change Log
 
+v0.4.0 (2015-07-16)
+
+- Update dependencies for both ES2015 and TypeScript builds.
+  - ES2015 dependency updates:
+    - minor updates to `file-loader` and `webpack-merge`
+    - major updates to `eslint` and `eslint-plugin-jsx-a11y`
+  - TypeScript dependency updates:
+    - `awesome-typescript-loader`
+    - `typings`
+- Minor tweaks to the example apps to reflect the new `action` decorator in `mobx`
+- the `build` task now performs file and chunk hashing, per the request in [Issue 4](https://github.com/cafreeman/generator-mobx-react/issues/4)
+- added `TSLint`, `tslint-react`, and a *very* minimal `tslint.json` config for the TypeScript build, per the request in [Issue 3](https://github.com/cafreeman/generator-mobx-react/issues/3)
+
 v0.3.1 (2016-05-29)
 
 - Updated version numbers for the following packages:

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -97,6 +97,8 @@ module.exports = yeoman.Base.extend({
             /* eslint-disable quotes */
             `"awesome-typescript-loader": "^1.0.0"`,
             `"react-hot-loader": "^1.3.0"`,
+            `"tslint": "^3.0.0"`,
+            `"tslint-react": "^0.4.0"`,
             `"typescript": "^1.8.0"`,
             `"typings": "^1.0.0"`,
             /* eslint-enable quotes */
@@ -136,6 +138,13 @@ module.exports = yeoman.Base.extend({
       );
     }
 
+    if (this.props.language === 'ts') {
+      this.fs.copy(
+        this.templatePath('_tslint.json'),
+        this.destinationPath('tslint.json')
+      );
+    }
+
     // webpack config
     this.fs.copyTpl(
       this.templatePath('_webpack.config.js'),
@@ -148,7 +157,8 @@ module.exports = yeoman.Base.extend({
 
     // copy app src, dependent on language choice
     this.fs.copyTpl(
-      this.templatePath(`src_${this.props.language === 'es2015' ? 'es2015' : 'ts'}`),
+      // this.templatePath(`src_${this.props.language === 'es2015' ? 'es2015' : 'ts'}`),
+      this.templatePath(`src_${this.props.language}`),
       this.destinationPath('src'),
       {
         name: this.props.name,

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -95,10 +95,10 @@ module.exports = yeoman.Base.extend({
         fullDeps = commonDeps.concat(
           [
             /* eslint-disable quotes */
-            `"awesome-typescript-loader": "^0.17.0"`,
+            `"awesome-typescript-loader": "^1.0.0"`,
             `"react-hot-loader": "^1.3.0"`,
             `"typescript": "^1.8.0"`,
-            `"typings": "^0.8.0"`,
+            `"typings": "^1.0.0"`,
             /* eslint-enable quotes */
           ]
         );
@@ -171,10 +171,10 @@ module.exports = yeoman.Base.extend({
         if (this.props.language === 'ts') {
           this.spawnCommandSync('./node_modules/.bin/typings', ['init']);
           this.spawnCommandSync('./node_modules/.bin/typings',
-            ['install', 'react', '--ambient', '--save']
+            ['install', 'react', '--save']
           );
           this.spawnCommandSync('./node_modules/.bin/typings',
-            ['install', 'react-dom', '--ambient', '--save']
+            ['install', 'react-dom', '--save']
           );
         }
       });

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -55,7 +55,7 @@ module.exports = yeoman.Base.extend({
       `"clean-webpack-plugin": "^0.1.0"`,
       `"css-loader": "^0.23.0"`,
       `"extract-text-webpack-plugin": "^1.0.0"`,
-      `"file-loader": "^0.8.0"`,
+      `"file-loader": "^0.9.0"`,
       `"html-webpack-plugin": "^2.15.0"`,
       `"npm-install-webpack-plugin": "^4.0.0"`,
       `"rimraf": "^2.5.0"`,
@@ -63,7 +63,7 @@ module.exports = yeoman.Base.extend({
       `"url-loader": "^0.5.0"`,
       `"webpack": "^1.12.0"`,
       `"webpack-dev-server": "^1.14.0"`,
-      `"webpack-merge": "^0.13.0"`,
+      `"webpack-merge": "^0.14.0"`,
       /* eslint-enable quotes */
     ];
 
@@ -83,11 +83,11 @@ module.exports = yeoman.Base.extend({
             `"babel-preset-react": "^6.0.0"`,
             `"babel-preset-react-hmre": "^1.0.0"`,
             `"babel-preset-stage-1": "^6.0.0"`,
-            `"eslint": "^2.11.0"`,
+            `"eslint": "^3.1.0"`,
             `"eslint-config-airbnb": "^9.0.0"`,
             `"eslint-plugin-import": "^1.8.0"`,
             `"eslint-plugin-react": "^5.1.0"`,
-            `"eslint-plugin-jsx-a11y": "^1.2.0"`,
+            `"eslint-plugin-jsx-a11y": "^2.0.0"`,
             /* eslint-enable quotes */
           ]
         );

--- a/generators/app/templates/_tsconfig.json
+++ b/generators/app/templates/_tsconfig.json
@@ -29,8 +29,8 @@
     "filesGlob": [
       "src/**/*.ts",
       "src/**/*.tsx",
-      "typings/main/**/*.d.ts",
-      "typings/main.d.ts",
+      "typings/**/*.d.ts",
+      "typings/index.d.ts",
       "!node_modules/**"
     ]
 }

--- a/generators/app/templates/_tslint.json
+++ b/generators/app/templates/_tslint.json
@@ -1,0 +1,10 @@
+{
+  "extends": ["tslint-react"],
+  "rules": {
+    "quotemark": [true, "single", "jsx-double"],
+    "jsx-alignment": true,
+    "jsx-self-close": true,
+    "jsx-no-string-ref": true,
+    "jsx-no-lambda": false
+  }
+}

--- a/generators/app/templates/_webpack.config.js
+++ b/generators/app/templates/_webpack.config.js
@@ -124,10 +124,10 @@ if (TARGET === 'build') {
     },
     output: {
       path: PATHS.build,
-      filename: '[name].js',
+      // filename: '[name].js',
       // Create a hash for each file in the build so we can detect which files have changed
-      // filename: '[name].[chunkhash].js',
-      // chunkFilename: '[chunkhash].js',
+      filename: '[name].[chunkhash].js',
+      chunkFilename: '[chunkhash].js',
     },
     module: {
       loaders: [
@@ -157,8 +157,8 @@ if (TARGET === 'build') {
       // Clear the contents of the build directory before re-building
       new CleanWebpackPlugin(PATHS.dist),
       // Output extracted CSS to its own file
-      new ExtractTextPlugin('[name].css'),
-      // new ExtractTextPlugin('[name].[chunkhash].css'),
+      // new ExtractTextPlugin('[name].css'),
+      new ExtractTextPlugin('[name].[chunkhash].css'),
       // Split dependencies into a `vendor` file and provide a manifest
       new webpack.optimize.CommonsChunkPlugin({
         names: ['vendor', 'manifest'],

--- a/generators/app/templates/src_es2015/Store.js
+++ b/generators/app/templates/src_es2015/Store.js
@@ -1,4 +1,4 @@
-import { observable, computed } from 'mobx';
+import { observable, computed, action } from 'mobx';
 
 class Store {
   name = '<%= name %>';
@@ -9,7 +9,7 @@ class Store {
     return this.numClicks % 2 === 0 ? 'even' : 'odd';
   }
 
-  clickButton() {
+  @action clickButton() {
     this.numClicks++;
   }
 }

--- a/generators/app/templates/src_ts/Store.ts
+++ b/generators/app/templates/src_ts/Store.ts
@@ -1,4 +1,4 @@
-import { observable, computed } from 'mobx';
+import { observable, computed, action } from 'mobx';
 
 class Store {
   name: string = '<%= name %>';
@@ -9,7 +9,7 @@ class Store {
     return this.numClicks % 2 === 0 ? 'even' : 'odd';
   }
 
-  clickButton(): void {
+  @action clickButton(): void {
     this.numClicks++;
   }
 }

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,16 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=759670
+	// for the documentation about the jsconfig.json format
+	"compilerOptions": {
+		"target": "es6",
+		"module": "commonjs",
+		"allowSyntheticDefaultImports": true
+	},
+	"exclude": [
+		"node_modules",
+		"bower_components",
+		"jspm_packages",
+		"tmp",
+		"temp"
+	]
+}


### PR DESCRIPTION
- Update dependencies for both ES2015 and TypeScript builds.
  - ES2015 dependency updates:
    - minor updates to `file-loader` and `webpack-merge`
    - major updates to `eslint` and `eslint-plugin-jsx-a11y`
  - TypeScript dependency updates:
    - `awesome-typescript-loader`
    - `typings`
- Minor tweaks to the example apps to reflect the new `action` decorator in `mobx`
- the `build` task now performs file and chunk hashing, per the request in [Issue 4](https://github.com/cafreeman/generator-mobx-react/issues/4)
- added `TSLint`, `tslint-react`, and a _very_ minimal `tslint.json` config for the TypeScript build, per the request in [Issue 3](https://github.com/cafreeman/generator-mobx-react/issues/3)
